### PR TITLE
Remove custom logo from customizer

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -91,7 +91,7 @@ if ( ! function_exists( '_s_setup' ) ) :
 		 *
 		 * @link https://codex.wordpress.org/Theme_Logo
 		 */
-		add_theme_support(
+		/*add_theme_support(
 			'custom-logo',
 			array(
 				'height'      => 250,
@@ -99,7 +99,7 @@ if ( ! function_exists( '_s_setup' ) ) :
 				'flex-width'  => true,
 				'flex-height' => true,
 			)
-		);
+		);*/
 	}
 endif;
 add_action( 'after_setup_theme', '_s_setup' );


### PR DESCRIPTION
Removed custom logo from customizer because Underscores custom header is not used by Mr.Dev.'s Framework.