### PR TITLE
v0.9.451

### DIFF
--- a/404.php
+++ b/404.php
@@ -22,6 +22,11 @@ get_header();
 			?>
 			<div class="page-content">
 				<p><?php esc_html_e( 'It looks like nothing was found at this location.', '_s' ); ?></p>
+				<div class="wp-block-buttons">
+					<div class="wp-block-button">
+						<a class="wp-block-button__link" href="<?php echo get_home_url(); ?>"><?php esc_html_e( 'Go to homepage', '_s' ); ?></a>
+					</div>
+				</div>
 			</div><!-- .page-content -->
 		</section><!-- .error-404 -->
 	</main><!-- #main -->

--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ Being fully compatible with the framework is not mandatory. But this theme is be
 - Removed customizer additions - Most of those additions were not needed: They would force the website to show the sitename on a specific place or are better kept to plugins such as Mr.Dev.'s Framework.
 - Removed forced image sizes on Woocommerce - Removed the default sizes of 150 and 300 for product images because those can be set using the Customizer. All other compatibility with Woocommerce and Jetpack was kept in this theme.
 - Limit post navigation to same categories.
+
+* To follow all the changes and improvements check the [closed requests](https://github.com/marcosrego-web/mrdev_s/pulls?q=is%3Apr+is%3Aclosed).

--- a/README.md
+++ b/README.md
@@ -18,12 +18,10 @@ Being fully compatible with the framework is not mandatory. But this theme is be
 
 - 4 sections when using Layout Control: Header Top, Main Content Top, Main Content Bottom and Footer Bottom.
 
-- Compatibility with every display option.
-
 **Some key differences vs Underscores:**
 
-- No default widgets and no forced logo or menu in the header - This is to better follow the new workflow on Wordpress _(using blocks and reusable blocks per page instead of widgets)_ and to prepare for the full site editor. You can still create new sidebars/sections using "layout control" on Mr.Dev.'s Framework.
+- Added default variables to core blocks.
+- No default widgets and no forced logo or menu in the header - This is to better follow the new workflow on Wordpress _(using blocks and reusable blocks per page instead of widgets)_ and to prepare for the full site editor. You can still create new sidebars/sections using "Blocks templates" from WP5.8 or "Layout control" on Mr.Dev.'s Framework.
 - Removed customizer additions - Most of those additions were not needed: They would force the website to show the sitename on a specific place or are better kept to plugins such as Mr.Dev.'s Framework.
 - Removed forced image sizes on Woocommerce - Removed the default sizes of 150 and 300 for product images because those can be set using the Customizer. All other compatibility with Woocommerce and Jetpack was kept in this theme.
 - Limit post navigation to same categories.
-- Templates support on the blocks editor.

--- a/functions.php
+++ b/functions.php
@@ -59,8 +59,6 @@ if ( ! function_exists( '_s_setup' ) ) :
 		);
 		// Add theme support for selective refresh for widgets.
 		add_theme_support( 'customize-selective-refresh-widgets' );
-		// Add templates support on the blocks editor.
-		add_theme_support( 'block-templates' );
 	}
 endif;
 add_action( 'after_setup_theme', '_s_setup' );

--- a/functions.php
+++ b/functions.php
@@ -8,7 +8,7 @@
  */
 if ( ! defined( '_S_VERSION' ) ) {
 	// Replace the version number of the theme on each release.
-	define( '_S_VERSION', '0.9.447' );
+	define( '_S_VERSION', '0.9.448' );
 }
 if ( ! function_exists( '_s_setup' ) ) :
 	/**

--- a/functions.php
+++ b/functions.php
@@ -8,7 +8,7 @@
  */
 if ( ! defined( '_S_VERSION' ) ) {
 	// Replace the version number of the theme on each release.
-	define( '_S_VERSION', '0.9.448' );
+	define( '_S_VERSION', '0.9.449' );
 }
 if ( ! function_exists( '_s_setup' ) ) :
 	/**

--- a/functions.php
+++ b/functions.php
@@ -8,7 +8,7 @@
  */
 if ( ! defined( '_S_VERSION' ) ) {
 	// Replace the version number of the theme on each release.
-	define( '_S_VERSION', '0.9.449' );
+	define( '_S_VERSION', '0.9.450' );
 }
 if ( ! function_exists( '_s_setup' ) ) :
 	/**

--- a/functions.php
+++ b/functions.php
@@ -8,7 +8,7 @@
  */
 if ( ! defined( '_S_VERSION' ) ) {
 	// Replace the version number of the theme on each release.
-	define( '_S_VERSION', '1.0.0' );
+	define( '_S_VERSION', '0.9.447' );
 }
 if ( ! function_exists( '_s_setup' ) ) :
 	/**

--- a/functions.php
+++ b/functions.php
@@ -8,7 +8,7 @@
  */
 if ( ! defined( '_S_VERSION' ) ) {
 	// Replace the version number of the theme on each release.
-	define( '_S_VERSION', '0.9.450' );
+	define( '_S_VERSION', '0.9.451' );
 }
 if ( ! function_exists( '_s_setup' ) ) :
 	/**

--- a/mrdev-framework/vars/styles.php
+++ b/mrdev-framework/vars/styles.php
@@ -70,10 +70,10 @@ ${"mrdev_style_color_value20"} = '#dc3232';
 ${"mrdev_style_color_opacity20"} = 1;
 //FONTS
 $mrdev_styles_fonts_number_default = 2;
-${"mrdev_style_font_name1"} = 'Heading Font';
+${"mrdev_style_font_name1"} = 'Font 1';
 ${"mrdev_style_font_value1"} = 'TimesNewRoman,Times New Roman,Times,Baskerville,Georgia,serif';
 ${"mrdev_style_font_url1"} = '';
-${"mrdev_style_font_name2"} = 'Text Font';
+${"mrdev_style_font_name2"} = 'Font 2';
 ${"mrdev_style_font_value2"} = 'Arial,Helvetica Neue,Helvetica';
 ${"mrdev_style_font_url2"} = '';
 //SIZES

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: mrdev, mrdev-framework, widgets, widget, widgetsarea, sidebar, custom-back
 Requires at least: 4.5
 Tested up to: 5.7
 Requires PHP: 5.6
-Stable tag: 0.9.450
+Stable tag: 0.9.451
 License: GNU General Public License v2 or later
 License URI: LICENSE
 
@@ -39,8 +39,7 @@ Mr.Dev_s includes support for Mr.Dev.'s Framework, WooCommerce and for Infinite 
 
 == Changelog ==
 
-= 0.9.41 - Jan 09 2021 =
-* Initial release
+* To know all the changes check the [closed requests on Mr.Dev_s github repository](https://github.com/marcosrego-web/mrdev_s/pulls?q=is%3Apr+is%3Aclosed).
 
 == Credits ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: mrdev, mrdev-framework, widgets, widget, widgetsarea, sidebar, custom-back
 Requires at least: 4.5
 Tested up to: 5.7
 Requires PHP: 5.6
-Stable tag: 0.9.41
+Stable tag: 0.9.450
 License: GNU General Public License v2 or later
 License URI: LICENSE
 
@@ -19,10 +19,11 @@ The easiest way to start creating with Mr.Dev.'s Framework!
 Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
 
 Some key differences:
-- No default widgets/sidebars/sections - This is to better follow the new workflow on Wordpress (using blocks and reusable blocks per page instead of widgets) and to prepare for the full site editor. You can still create new sidebars/sections using "layout control" on Mr.Dev.'s Framework.
-- No forced logo or menu in the header - You can use widgets instead. Create new sidebars/sections for those widgets using "layout control" on Mr.Dev.'s Framework.
+- Added default variables to core blocks.
+- No default widgets and no forced logo or menu in the header - This is to better follow the new workflow on Wordpress _(using blocks and reusable blocks per page instead of widgets)_ and to prepare for the full site editor. You can still create new sidebars/sections using "Blocks templates" from WP5.8 or "Layout control" on Mr.Dev.'s Framework.
+- Removed customizer additions - Most of those additions were not needed: They would force the website to show the sitename on a specific place or are better kept to plugins such as Mr.Dev.'s Framework.
+- Removed forced image sizes on Woocommerce - Removed the default sizes of 150 and 300 for product images because those can be set using the Customizer. All other compatibility with Woocommerce and Jetpack was kept in this theme.
 - Limit post navigation to same categories.
-- Templates support on the blocks editor.
 
 == Installation ==
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4,7 +4,7 @@ Theme URI: https://marcosrego.com/web/mrdev/
 Author: Marcos Rego
 Author URI: https://marcosrego.com
 Description: The easiest way to start creating with Mr.Dev.'s Framework! Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
-Version: 0.9.450
+Version: 0.9.451
 Tested up to: 5.4
 Requires PHP: 5.6
 License: GNU General Public License v2 or later
@@ -648,6 +648,10 @@ a:focus {
 --------------------------------------------------------------*/
 /* Other style changes
 --------------------------------------------- */
+:root {
+  --gallery-block--gutter-size: var(--margin, 16px);
+  --wp--style--block-gap: var(--margin, 2em);
+}
 html {
   height: 100%;
   font-size: var(--base, 100%);
@@ -663,14 +667,34 @@ html {
 .wp-block-latest-posts.is-grid li {
   margin: 0 var(--margin, 1.25rem) var(--margin, 1.25rem) 0;
 }
-.wp-block-post-template.is-flex-container li,
-.wp-block-query-loop.is-flex-container li {
-  margin: 0 0 var(--margin, 1.25rem);
+.wp-block-post-template.is-flex-container,
+.wp-block-query-loop.is-flex-container {
+  gap: var(--margin);
+}
+.wp-block-buttons > .wp-block-button {
+  margin-bottom: var(--margin, 1.25rem);
+  margin-right: var(--margin, 1.25rem);
 }
 @media (min-width: 600px) {
-  .wp-block-post-template.is-flex-container li,
-  .wp-block-query-loop.is-flex-container li {
-    margin-right: var(--margin, 1.25rem);
+  .wp-block-post-template.is-flex-container.is-flex-container.columns-2 > li,
+  .wp-block-query-loop.is-flex-container.is-flex-container.columns-2 > li {
+    width: calc(50% - (var(--margin) / 2));
+  }
+  .wp-block-post-template.is-flex-container.is-flex-container.columns-3 > li,
+  .wp-block-query-loop.is-flex-container.is-flex-container.columns-3 > li {
+    width: calc(33.33333% - (var(--margin) / 2));
+  }
+  .wp-block-post-template.is-flex-container.is-flex-container.columns-4 > li,
+  .wp-block-query-loop.is-flex-container.is-flex-container.columns-4 > li {
+    width: calc(25% - (var(--margin) / 2));
+  }
+  .wp-block-post-template.is-flex-container.is-flex-container.columns-5 > li,
+  .wp-block-query-loop.is-flex-container.is-flex-container.columns-5 > li {
+    width: calc(20% - (var(--margin) / 2));
+  }
+  .wp-block-post-template.is-flex-container.is-flex-container.columns-6 > li,
+  .wp-block-query-loop.is-flex-container.is-flex-container.columns-6 > li {
+    width: calc(16.66666% - (var(--margin) / 2));
   }
 }
 @media (min-width: 782px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -725,7 +725,8 @@ h6:not(.has-text-color) {
   color: var(--text-color, #434b5c);
 }
 .mr-header,
-.post-template .wp-site-blocks > header {
+.post-template .wp-site-blocks > header,
+.page-template .wp-site-blocks > header {
   background-color: var(--header-background-color, #757d98);
 }
 .mr-header,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4,7 +4,7 @@ Theme URI: https://marcosrego.com/web/mrdev/
 Author: Marcos Rego
 Author URI: https://marcosrego.com
 Description: The easiest way to start creating with Mr.Dev.'s Framework! Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
-Version: 0.9.447
+Version: 0.9.448
 Tested up to: 5.4
 Requires PHP: 5.6
 License: GNU General Public License v2 or later
@@ -339,7 +339,7 @@ select,
 optgroup,
 textarea {
   color: var(--text-color, #404040);
-  font-family: var(--text-font, sans-serif);
+  font-family: var(--font-2, sans-serif);
   font-size: var(--font-size-4, 1rem);
   line-height: var(--line-height, 1.5);
 }
@@ -349,7 +349,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: var(--heading-font, serif);
+  font-family: var(--font-1, serif);
   clear: both;
   font-weight: unset;
 }
@@ -369,7 +369,6 @@ address {
   margin: 0 0 var(--margin, 1.5rem);
 }
 pre {
-  background: #eee;
   font-family: "Courier 10 Pitch", courier, monospace;
   line-height: 1.6;
   margin-bottom: 1.6em;
@@ -685,7 +684,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: var(--heading-font, serif);
+  font-family: var(--font-1, serif);
   margin: var(--margin, 0.67rem) 0;
 }
 h1 {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4,7 +4,7 @@ Theme URI: https://marcosrego.com/web/mrdev/
 Author: Marcos Rego
 Author URI: https://marcosrego.com
 Description: The easiest way to start creating with Mr.Dev.'s Framework! Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
-Version: 0.9.448
+Version: 0.9.449
 Tested up to: 5.4
 Requires PHP: 5.6
 License: GNU General Public License v2 or later
@@ -742,11 +742,19 @@ h6:not(.has-text-color) {
 .post-template .wp-site-blocks > header h4:not(.has-text-color),
 .post-template .wp-site-blocks > header h5:not(.has-text-color),
 .post-template .wp-site-blocks > header h6:not(.has-text-color),
-.post-template .wp-site-blocks > header a:not(.has-text-color) {
+.post-template .wp-site-blocks > header a:not(.has-text-color),
+.page-template .wp-site-blocks > header h1:not(.has-text-color),
+.page-template .wp-site-blocks > header h2:not(.has-text-color),
+.page-template .wp-site-blocks > header h3:not(.has-text-color),
+.page-template .wp-site-blocks > header h4:not(.has-text-color),
+.page-template .wp-site-blocks > header h5:not(.has-text-color),
+.page-template .wp-site-blocks > header h6:not(.has-text-color),
+.page-template .wp-site-blocks > header a:not(.has-text-color) {
   color: var(--header-text-color, #8cc7c2);
 }
 .mr-main,
-.post-template .wp-site-blocks > main {
+.post-template .wp-site-blocks > main,
+.page-template .wp-site-blocks > main {
   background: var(--main-background-color, #dfdfd0);
 }
 .mr-main,
@@ -763,7 +771,14 @@ h6:not(.has-text-color) {
 .post-template .wp-site-blocks > main h4:not(.has-text-color),
 .post-template .wp-site-blocks > main h5:not(.has-text-color),
 .post-template .wp-site-blocks > main h6:not(.has-text-color),
-.post-template .wp-site-blocks > main a:not(.has-text-color) {
+.post-template .wp-site-blocks > main a:not(.has-text-color),
+.page-template .wp-site-blocks > main h1:not(.has-text-color),
+.page-template .wp-site-blocks > main h2:not(.has-text-color),
+.page-template .wp-site-blocks > main h3:not(.has-text-color),
+.page-template .wp-site-blocks > main h4:not(.has-text-color),
+.page-template .wp-site-blocks > main h5:not(.has-text-color),
+.page-template .wp-site-blocks > main h6:not(.has-text-color),
+.page-template .wp-site-blocks > main a:not(.has-text-color) {
   color: var(--main-text-color, #434b5c);
 }
 .mr-aside {
@@ -780,7 +795,8 @@ h6:not(.has-text-color) {
   color: var(--aside-text-color, #434b5c);
 }
 .mr-footer,
-.post-template .wp-site-blocks > footer {
+.post-template .wp-site-blocks > footer,
+.page-template .wp-site-blocks > footer {
   background-color: var(--footer-background-color, #757d98);
 }
 .mr-footer,
@@ -797,6 +813,13 @@ h6:not(.has-text-color) {
 .post-template .wp-site-blocks > footer h4:not(.has-text-color),
 .post-template .wp-site-blocks > footer h5:not(.has-text-color),
 .post-template .wp-site-blocks > footer h6:not(.has-text-color),
-.post-template .wp-site-blocks > footer a:not(.has-text-color) {
+.post-template .wp-site-blocks > footer a:not(.has-text-color),
+.page-template .wp-site-blocks > footer h1:not(.has-text-color),
+.page-template .wp-site-blocks > footer h2:not(.has-text-color),
+.page-template .wp-site-blocks > footer h3:not(.has-text-color),
+.page-template .wp-site-blocks > footer h4:not(.has-text-color),
+.page-template .wp-site-blocks > footer h5:not(.has-text-color),
+.page-template .wp-site-blocks > footer h6:not(.has-text-color),
+.page-template .wp-site-blocks > footer a:not(.has-text-color) {
   color: var(--footer-text-color, rgba(255, 255, 255, 0.5));
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4,7 +4,7 @@ Theme URI: https://marcosrego.com/web/mrdev/
 Author: Marcos Rego
 Author URI: https://marcosrego.com
 Description: The easiest way to start creating with Mr.Dev.'s Framework! Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
-Version: 0.9.446
+Version: 0.9.447
 Tested up to: 5.4
 Requires PHP: 5.6
 License: GNU General Public License v2 or later
@@ -79,7 +79,7 @@ main {
  * 1. Add the correct box sizing in Firefox.
  * 2. Show the overflow in Edge and IE.
  */
-hr {
+hr:not(.wp-block-separator) {
   box-sizing: content-box;
   height: 0;
   overflow: visible;
@@ -401,13 +401,11 @@ big {
 body:not(.has-background) {
   background: var(--background-color, #fff);
 }
-hr:not(.has-background) {
-  background-color: var(--text-color, #ccc);
-}
-hr {
+hr:not(.wp-block-separator) {
   border: 0;
   height: 1px;
   margin-bottom: var(--margin, 1.5rem);
+  background-color: var(--text-color, #ccc);
 }
 ul,
 ol {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4,7 +4,7 @@ Theme URI: https://marcosrego.com/web/mrdev/
 Author: Marcos Rego
 Author URI: https://marcosrego.com
 Description: The easiest way to start creating with Mr.Dev.'s Framework! Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
-Version: 0.9.449
+Version: 0.9.450
 Tested up to: 5.4
 Requires PHP: 5.6
 License: GNU General Public License v2 or later
@@ -659,6 +659,19 @@ html {
 }
 .wp-block-columns {
   margin-bottom: var(--margin, 1.75rem);
+}
+.wp-block-latest-posts.is-grid li {
+  margin: 0 var(--margin, 1.25rem) var(--margin, 1.25rem) 0;
+}
+.wp-block-post-template.is-flex-container li,
+.wp-block-query-loop.is-flex-container li {
+  margin: 0 0 var(--margin, 1.25rem);
+}
+@media (min-width: 600px) {
+  .wp-block-post-template.is-flex-container li,
+  .wp-block-query-loop.is-flex-container li {
+    margin-right: var(--margin, 1.25rem);
+  }
 }
 @media (min-width: 782px) {
   .wp-block-column:not(:first-child) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4,7 +4,7 @@ Theme URI: https://marcosrego.com/web/mrdev/
 Author: Marcos Rego
 Author URI: https://marcosrego.com
 Description: The easiest way to start creating with Mr.Dev.'s Framework! Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
-Version: 0.9.445
+Version: 0.9.446
 Tested up to: 5.4
 Requires PHP: 5.6
 License: GNU General Public License v2 or later

--- a/style.css
+++ b/style.css
@@ -724,7 +724,8 @@ h6:not(.has-text-color) {
   color: var(--text-color, #434b5c);
 }
 .mr-header,
-.post-template .wp-site-blocks > header {
+.post-template .wp-site-blocks > header,
+.page-template .wp-site-blocks > header {
   background-color: var(--header-background-color, #757d98);
 }
 .mr-header,

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://marcosrego.com/web/mrdev/
 Author: Marcos Rego
 Author URI: https://marcosrego.com
 Description: The easiest way to start creating with Mr.Dev.'s Framework! Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
-Version: 0.9.449
+Version: 0.9.450
 Tested up to: 5.4
 Requires PHP: 5.6
 License: GNU General Public License v2 or later
@@ -658,6 +658,19 @@ html {
 }
 .wp-block-columns {
   margin-bottom: var(--margin, 1.75rem);
+}
+.wp-block-latest-posts.is-grid li {
+  margin: 0 var(--margin, 1.25rem) var(--margin, 1.25rem) 0;
+}
+.wp-block-post-template.is-flex-container li,
+.wp-block-query-loop.is-flex-container li {
+  margin: 0 0 var(--margin, 1.25rem);
+}
+@media (min-width: 600px) {
+  .wp-block-post-template.is-flex-container li,
+  .wp-block-query-loop.is-flex-container li {
+    margin-right: var(--margin, 1.25rem);
+  }
 }
 @media (min-width: 782px) {
   .wp-block-column:not(:first-child) {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://marcosrego.com/web/mrdev/
 Author: Marcos Rego
 Author URI: https://marcosrego.com
 Description: The easiest way to start creating with Mr.Dev.'s Framework! Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
-Version: 0.9.447
+Version: 0.9.448
 Tested up to: 5.4
 Requires PHP: 5.6
 License: GNU General Public License v2 or later
@@ -338,7 +338,7 @@ select,
 optgroup,
 textarea {
   color: var(--text-color, #404040);
-  font-family: var(--text-font, sans-serif);
+  font-family: var(--font-2, sans-serif);
   font-size: var(--font-size-4, 1rem);
   line-height: var(--line-height, 1.5);
 }
@@ -367,7 +367,6 @@ address {
   margin: 0 0 var(--margin, 1.5rem);
 }
 pre {
-  background: #eee;
   font-family: "Courier 10 Pitch", courier, monospace;
   line-height: var(--line-height, 1.6);
   margin-bottom: var(--margin, 1.6rem);
@@ -684,7 +683,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: var(--heading-font, serif);
+  font-family: var(--font-1, serif);
   margin: var(--margin, 0.67rem) 0;
 }
 h1 {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://marcosrego.com/web/mrdev/
 Author: Marcos Rego
 Author URI: https://marcosrego.com
 Description: The easiest way to start creating with Mr.Dev.'s Framework! Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
-Version: 0.9.450
+Version: 0.9.451
 Tested up to: 5.4
 Requires PHP: 5.6
 License: GNU General Public License v2 or later
@@ -647,6 +647,10 @@ a:focus {
 }
 /* Other style changes
 --------------------------------------------- */
+:root {
+  --gallery-block--gutter-size: var(--margin, 16px);
+  --wp--style--block-gap: var(--margin, 2em);
+}
 html {
   height: 100%;
   font-size: var(--base, 100%);
@@ -662,14 +666,34 @@ html {
 .wp-block-latest-posts.is-grid li {
   margin: 0 var(--margin, 1.25rem) var(--margin, 1.25rem) 0;
 }
-.wp-block-post-template.is-flex-container li,
-.wp-block-query-loop.is-flex-container li {
-  margin: 0 0 var(--margin, 1.25rem);
+.wp-block-post-template.is-flex-container,
+.wp-block-query-loop.is-flex-container {
+  gap: var(--margin);
+}
+.wp-block-buttons > .wp-block-button {
+  margin-bottom: var(--margin, 1.25rem);
+  margin-right: var(--margin, 1.25rem);
 }
 @media (min-width: 600px) {
-  .wp-block-post-template.is-flex-container li,
-  .wp-block-query-loop.is-flex-container li {
-    margin-right: var(--margin, 1.25rem);
+  .wp-block-post-template.is-flex-container.is-flex-container.columns-2 > li,
+  .wp-block-query-loop.is-flex-container.is-flex-container.columns-2 > li {
+    width: calc(50% - (var(--margin) / 2));
+  }
+  .wp-block-post-template.is-flex-container.is-flex-container.columns-3 > li,
+  .wp-block-query-loop.is-flex-container.is-flex-container.columns-3 > li {
+    width: calc(33.33333% - (var(--margin) / 2));
+  }
+  .wp-block-post-template.is-flex-container.is-flex-container.columns-4 > li,
+  .wp-block-query-loop.is-flex-container.is-flex-container.columns-4 > li {
+    width: calc(25% - (var(--margin) / 2));
+  }
+  .wp-block-post-template.is-flex-container.is-flex-container.columns-5 > li,
+  .wp-block-query-loop.is-flex-container.is-flex-container.columns-5 > li {
+    width: calc(20% - (var(--margin) / 2));
+  }
+  .wp-block-post-template.is-flex-container.is-flex-container.columns-6 > li,
+  .wp-block-query-loop.is-flex-container.is-flex-container.columns-6 > li {
+    width: calc(16.66666% - (var(--margin) / 2));
   }
 }
 @media (min-width: 782px) {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://marcosrego.com/web/mrdev/
 Author: Marcos Rego
 Author URI: https://marcosrego.com
 Description: The easiest way to start creating with Mr.Dev.'s Framework! Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
-Version: 0.9.448
+Version: 0.9.449
 Tested up to: 5.4
 Requires PHP: 5.6
 License: GNU General Public License v2 or later
@@ -741,11 +741,19 @@ h6:not(.has-text-color) {
 .post-template .wp-site-blocks > header h4:not(.has-text-color),
 .post-template .wp-site-blocks > header h5:not(.has-text-color),
 .post-template .wp-site-blocks > header h6:not(.has-text-color),
-.post-template .wp-site-blocks > header a:not(.has-text-color) {
+.post-template .wp-site-blocks > header a:not(.has-text-color),
+.page-template .wp-site-blocks > header h1:not(.has-text-color),
+.page-template .wp-site-blocks > header h2:not(.has-text-color),
+.page-template .wp-site-blocks > header h3:not(.has-text-color),
+.page-template .wp-site-blocks > header h4:not(.has-text-color),
+.page-template .wp-site-blocks > header h5:not(.has-text-color),
+.page-template .wp-site-blocks > header h6:not(.has-text-color),
+.page-template .wp-site-blocks > header a:not(.has-text-color) {
   color: var(--header-text-color, #8cc7c2);
 }
 .mr-main,
-.post-template .wp-site-blocks > main {
+.post-template .wp-site-blocks > main,
+.page-template .wp-site-blocks > main {
   background: var(--main-background-color, #dfdfd0);
 }
 .mr-main,
@@ -762,7 +770,14 @@ h6:not(.has-text-color) {
 .post-template .wp-site-blocks > main h4:not(.has-text-color),
 .post-template .wp-site-blocks > main h5:not(.has-text-color),
 .post-template .wp-site-blocks > main h6:not(.has-text-color),
-.post-template .wp-site-blocks > main a:not(.has-text-color) {
+.post-template .wp-site-blocks > main a:not(.has-text-color),
+.page-template .wp-site-blocks > main h1:not(.has-text-color),
+.page-template .wp-site-blocks > main h2:not(.has-text-color),
+.page-template .wp-site-blocks > main h3:not(.has-text-color),
+.page-template .wp-site-blocks > main h4:not(.has-text-color),
+.page-template .wp-site-blocks > main h5:not(.has-text-color),
+.page-template .wp-site-blocks > main h6:not(.has-text-color),
+.page-template .wp-site-blocks > main a:not(.has-text-color) {
   color: var(--main-text-color, #434b5c);
 }
 .mr-aside {
@@ -779,7 +794,8 @@ h6:not(.has-text-color) {
   color: var(--aside-text-color, #434b5c);
 }
 .mr-footer,
-.post-template .wp-site-blocks > footer {
+.post-template .wp-site-blocks > footer,
+.page-template .wp-site-blocks > footer {
   background-color: var(--footer-background-color, #757d98);
 }
 .mr-footer,
@@ -796,6 +812,13 @@ h6:not(.has-text-color) {
 .post-template .wp-site-blocks > footer h4:not(.has-text-color),
 .post-template .wp-site-blocks > footer h5:not(.has-text-color),
 .post-template .wp-site-blocks > footer h6:not(.has-text-color),
-.post-template .wp-site-blocks > footer a:not(.has-text-color) {
+.post-template .wp-site-blocks > footer a:not(.has-text-color),
+.page-template .wp-site-blocks > footer h1:not(.has-text-color),
+.page-template .wp-site-blocks > footer h2:not(.has-text-color),
+.page-template .wp-site-blocks > footer h3:not(.has-text-color),
+.page-template .wp-site-blocks > footer h4:not(.has-text-color),
+.page-template .wp-site-blocks > footer h5:not(.has-text-color),
+.page-template .wp-site-blocks > footer h6:not(.has-text-color),
+.page-template .wp-site-blocks > footer a:not(.has-text-color) {
   color: var(--footer-text-color, rgba(255, 255, 255, 0.5));
 }

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://marcosrego.com/web/mrdev/
 Author: Marcos Rego
 Author URI: https://marcosrego.com
 Description: The easiest way to start creating with Mr.Dev.'s Framework! Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
-Version: 0.9.446
+Version: 0.9.447
 Tested up to: 5.4
 Requires PHP: 5.6
 License: GNU General Public License v2 or later
@@ -78,7 +78,7 @@ main {
  * 1. Add the correct box sizing in Firefox.
  * 2. Show the overflow in Edge and IE.
  */
-hr {
+hr:not(.wp-block-separator) {
   box-sizing: content-box;
   height: 0;
   overflow: visible;
@@ -399,13 +399,11 @@ big {
 body {
   background: var(--background-color, #fff);
 }
-hr:not(.has-background) {
-  background-color: var(--text-color, #ccc);
-}
-hr {
+hr:not(.wp-block-separator) {
   border: 0;
   height: 1px;
   margin-bottom: var(--margin, 1.5rem);
+  background-color: var(--text-color, #ccc);
 }
 ul,
 ol {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://marcosrego.com/web/mrdev/
 Author: Marcos Rego
 Author URI: https://marcosrego.com
 Description: The easiest way to start creating with Mr.Dev.'s Framework! Mr.Dev. grabbed Underscores, the famous starter theme for Wordpress, and made it fully compatible with each and every feature of his Framework.
-Version: 0.9.445
+Version: 0.9.446
 Tested up to: 5.4
 Requires PHP: 5.6
 License: GNU General Public License v2 or later


### PR DESCRIPTION
- WP5.9 block gap vars + Link on 404 page
- Quickfix: Missing one instance of page template
- Added default styles to page templates not only post templates
- Changed font styles to match Mr.Utils defaults
- Missing version update on php file
- Do not add hr style to wp-block-separator
- Let the Framework decide the use of block templates